### PR TITLE
fix(tools): spec name as string

### DIFF
--- a/packages/autocomplete-tools/scripts/create-spec.ts
+++ b/packages/autocomplete-tools/scripts/create-spec.ts
@@ -5,7 +5,7 @@ import path from "path";
 import chalk from "chalk";
 
 const fileContent = (name: string) => `const completionSpec: Fig.Spec = {
-  name: ${name},
+  name: "${name}",
   description: "",
   subcommands: [{
     name: "my_subcommand",


### PR DESCRIPTION
Spec name is missing surrounding quotes so it gets added as a variable.

Ex:
Spec currently generated with:
```
name: specName,
```

should be:
```
name: "specName",
```
