### PR TITLE
Export generateCommand function - we may want to modify before writing

### DIFF
--- a/packages/commander/src/index.ts
+++ b/packages/commander/src/index.ts
@@ -123,7 +123,7 @@ function helpOption({
   };
 }
 
-function generateCommand(
+export function generateCommand(
   _command: Command & Record<string, any>,
   figSpecCommandName: string
 ): Fig.Subcommand | undefined {


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature 

**What is the current behavior? (You can also link to an open issue here)**

You cannot edit the spec before it is written to file.

**What is the new behavior (if this is a feature change)?**

This allows package consumers to call the `generateCommand` function directly, as they may want to edit the output before it is written to a file.

**Additional info:**