### PR TITLE
Add support for hidden commands

### DIFF
--- a/packages/autocomplete-tools/merge/presets.ts
+++ b/packages/autocomplete-tools/merge/presets.ts
@@ -19,7 +19,7 @@ export const defaultPreset: Preset = {
 
 export const presets: Record<string, Preset> = {
   commander: {
-    commandProps: new Set(["name", "description", "subcommands", "options", "args"]),
+    commandProps: new Set(["name", "description", "subcommands", "options", "args", "hidden"]),
     optionProps: new Set(["name", "description", "isRequired", "args"]),
     argProps: new Set([
       "name",

--- a/packages/commander/src/index.ts
+++ b/packages/commander/src/index.ts
@@ -93,6 +93,7 @@ interface ExtendedCommand extends Command {
   _helpCommandnameAndArgs: string;
   _helpCommandDescription: string;
   _hasHelpOption: boolean;
+  _hidden: boolean;
 }
 
 function helpSubcommand({
@@ -136,6 +137,7 @@ function generateCommand(
     options,
     _addImplicitHelpCommandL,
     _hasHelpOption,
+    _hidden,
   } = _command as ExtendedCommand;
 
   if (_name === figSpecCommandName) return undefined;
@@ -143,6 +145,7 @@ function generateCommand(
   const command: Fig.Subcommand = { name };
 
   if (_description) command.description = _description;
+  if (_hidden) command.hidden = true;
   // Subcommands
   if (commands.length) {
     command.subcommands = [];


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
Commands marked as hidden in `commander` still appear as regular suggestions in Fig.

**What is the new behavior (if this is a feature change)?**
Hidden `commander` commands will be also marked as hidden in Fig.

**Additional info:**