### PR TITLE
fix(click_complete_fig): fix packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist-ssr
 build/
 .yarn/
 *.log
+.python-version

--- a/integrations/click/setup.cfg
+++ b/integrations/click/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = click_complete_fig
-version = 1.0.0
+version = 1.1.0
 author = Fig
 author_email = hello@fig.io
 description =  Autogenerate Completions for CLI tools built with click
@@ -17,9 +17,11 @@ classifiers =
     Operating System :: OS Independent
 
 [options]
-package_dir =
-    = click_complete_fig
+packages = find:
 python_requires = >=3.6
 
 install_requires=
     click
+
+[options.packages.find]
+where=.


### PR DESCRIPTION
use setuptools's autodiscovery of package files instead of manually
specifying directory
