### PR TITLE
fix(types): remove optionality from required param (Fig.Function)

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -145,7 +145,7 @@ declare namespace Fig {
    * @param param - A param of type `R`
    * @returns Something of type `R`
    */
-  type Function<T = void, R = void> = (param?: T) => R;
+  type Function<T = void, R = void> = (param: T) => R;
 
   /**
    * A utility type to modify a property type


### PR DESCRIPTION
Just like the last time, _technically_ this is a breaking change but it actually aligns the types with reality and since we're the only consumers of these types it doesn't break anything.

I ran this against https://github.com/withfig/autocomplete and there were no errors at all (because it's not in strict mode, so everything expects this param to be a string instead of undefined)

