### PR TITLE
feat(keyval): improve caching, use `insertValue`, add `valueList`

### DIFF
--- a/generators/src/keyvalue.ts
+++ b/generators/src/keyvalue.ts
@@ -97,7 +97,7 @@ async function getSuggestions(
   useSuggestionCache: boolean,
   init: Parameters<NonNullable<Fig.Generator["custom"]>>
 ): Promise<Fig.Suggestion[]> {
-  if (useSuggestionCache) {
+  if (useSuggestionCache || suggestions instanceof Array) {
     if (!suggestionCache.has(suggestions)) {
       suggestionCache.set(
         suggestions,

--- a/generators/src/keyvalue.ts
+++ b/generators/src/keyvalue.ts
@@ -136,7 +136,7 @@ function lastIndexOf(haystack: string, ...needles: string[]) {
  *
  * The primary use of this is to enable the same caching behavior as `keyValue`
  * and `keyValueList`. If your goal is to create a $PATH-like value, use a generator
- * literal: `{ template: "filepaths", trigger: ":", getQueryTerm: ":" }`
+ * object literal: `{ template: "filepaths", trigger: ":", getQueryTerm: ":" }`
  */
 export function valueList({
   delimiter = ",",
@@ -153,13 +153,18 @@ export function valueList({
 
 /**
  * Create a generator that gives suggestions for key=value arguments. You
- * can use a `string[]` or `Fig.Suggestion[]` for the keys and values.
+ * can use a `string[]` or `Fig.Suggestion[]` for the keys and values, or a
+ * function with the same signature as `Fig.Generator["custom"]`.
  *
  * You can set `cache: true` to enable caching results. The suggestions are cached
  * globally using the function as a key, so enabling caching for any one generator
  * will set the cache values for the functions for the entire spec. This behavior
  * can be used to copmpose expensive key/value generators without incurring the
  * initial cost every time they're used.
+ *
+ * Note that you should only cache generators that produce the same output regardless
+ * of their input. You can cache either the keys or values individually using `"keys"`
+ * or `"values"` as the `cache` property value.
  *
  * @example
  *
@@ -215,13 +220,18 @@ export function keyValue({
 
 /**
  * Create a generator that gives suggestions for `k=v,k=v,...` arguments. You
- * can use a `string[]` or `Fig.Suggestion[]` for the keys and values.
+ * can use a `string[]` or `Fig.Suggestion[]` for the keys and values, or a
+ * function with the same signature as `Fig.Generator["custom"]`
  *
  * You can set `cache: true` to enable caching results. The suggestions are cached
  * globally using the function as a key, so enabling caching for any one generator
  * will set the cache values for the functions for the entire spec. This behavior
  * can be used to copmpose expensive key/value generators without incurring the
  * initial cost every time they're used.
+ *
+ * Note that you should only cache generators that produce the same output regardless
+ * of their input. You can cache either the keys or values individually using `"keys"`
+ * or `"values"` as the `cache` property value.
  *
  * @example
  *

--- a/generators/test/keyvalue.test.ts
+++ b/generators/test/keyvalue.test.ts
@@ -55,10 +55,37 @@ describe("Test keyValue suggestions", () => {
         keys: ["a", "b", "c"],
         values: ["1", "2", "3"],
         separator: ":",
+        insertSeparator: false,
       })
     );
     await test("", [{ name: "a" }, { name: "b" }, { name: "c" }]);
     await test("key", [{ name: "a" }, { name: "b" }, { name: "c" }]);
+    await test(":", [{ name: "1" }, { name: "2" }, { name: "3" }]);
+    await test("key:", [{ name: "1" }, { name: "2" }, { name: "3" }]);
+    await test("key:val", [{ name: "1" }, { name: "2" }, { name: "3" }]);
+  });
+
+  it("can append the separator to keys", async () => {
+    const test = kvSuggestionsTest(
+      keyValue({
+        keys: ["a", "b", "c"],
+        values: ["1", "2", "3"],
+        separator: ":",
+        // The default behavior is to insert the separator
+        // insertSeparator:false
+      })
+    );
+    await test("", [
+      { name: "a", insertValue: "a:" },
+      { name: "b", insertValue: "b:" },
+      { name: "c", insertValue: "c:" },
+    ]);
+    await test("key", [
+      { name: "a", insertValue: "a:" },
+      { name: "b", insertValue: "b:" },
+      { name: "c", insertValue: "c:" },
+    ]);
+    // checking that the value suggestions don't have the separator
     await test(":", [{ name: "1" }, { name: "2" }, { name: "3" }]);
     await test("key:", [{ name: "1" }, { name: "2" }, { name: "3" }]);
     await test("key:val", [{ name: "1" }, { name: "2" }, { name: "3" }]);
@@ -70,6 +97,7 @@ describe("Test keyValue suggestions", () => {
         keys: () => Promise.resolve([{ name: "key" }]),
         values: () => Promise.resolve([{ name: "value" }]),
         separator: ":",
+        insertSeparator: false,
       })
     );
     await test("", [{ name: "key" }]);
@@ -94,6 +122,7 @@ describe("Test keyValue suggestions", () => {
         keys: getKeys,
         values: getValues,
         cache: true,
+        insertSeparator: false,
       })
     );
     expect(getKeysCalled).to.be.equal(0);
@@ -136,6 +165,7 @@ describe("Test keyValue suggestions", () => {
         keys: getKeys,
         values: getValues,
         cache: "keys",
+        insertSeparator: false,
       })
     );
     expect(getKeysCalled).to.be.equal(0);
@@ -178,6 +208,7 @@ describe("Test keyValue suggestions", () => {
         keys: getKeys,
         values: getValues,
         cache: "values",
+        insertSeparator: false,
       })
     );
     expect(getKeysCalled).to.be.equal(0);
@@ -238,6 +269,7 @@ describe("Test keyValueList suggestions", () => {
         values: ["1", "2", "3"],
         separator: "=",
         delimiter: ",",
+        insertSeparator: false,
       })
     );
     await test("", [{ name: "a" }, { name: "b" }, { name: "c" }]);
@@ -255,12 +287,38 @@ describe("Test keyValueList suggestions", () => {
     await test("key=value,=", [{ name: "1" }, { name: "2" }, { name: "3" }]);
   });
 
+  it("can insert the separator and delimiter", async () => {
+    const test = kvSuggestionsTest(
+      keyValueList({
+        keys: ["a"],
+        values: ["1"],
+        separator: "=",
+        delimiter: ",",
+        insertSeparator: true,
+        insertDelimiter: true,
+      })
+    );
+    await test("", [{ name: "a", insertValue: "a=" }]);
+    await test("key", [{ name: "a", insertValue: "a=" }]);
+    await test("=", [{ name: "1", insertValue: "1," }]);
+    await test("key=", [{ name: "1", insertValue: "1," }]);
+    await test("key=val", [{ name: "1", insertValue: "1," }]);
+
+    await test(",", [{ name: "a", insertValue: "a=" }]);
+    await test("key,", [{ name: "a", insertValue: "a=" }]);
+    await test("key=value,", [{ name: "a", insertValue: "a=" }]);
+    await test("key=,", [{ name: "a", insertValue: "a=" }]);
+
+    await test("key=value,key2=", [{ name: "1", insertValue: "1," }]);
+    await test("key=value,=", [{ name: "1", insertValue: "1," }]);
+  });
   it("runs functions", async () => {
     const test = kvSuggestionsTest(
       keyValueList({
         keys: () => Promise.resolve([{ name: "key" }]),
         values: () => Promise.resolve([{ name: "value" }]),
         separator: ":",
+        insertSeparator: false,
       })
     );
     await test("", [{ name: "key" }]);
@@ -285,6 +343,7 @@ describe("Test keyValueList suggestions", () => {
         keys: getKeys,
         values: getValues,
         cache: true,
+        insertSeparator: false,
       })
     );
     expect(getKeysCalled).to.be.equal(0);
@@ -341,6 +400,7 @@ describe("Test keyValueList suggestions", () => {
         keys: getKeys,
         values: getValues,
         cache: "keys",
+        insertSeparator: false,
       })
     );
 
@@ -398,6 +458,7 @@ describe("Test keyValueList suggestions", () => {
         keys: getKeys,
         values: getValues,
         cache: "values",
+        insertSeparator: false,
       })
     );
 

--- a/generators/test/keyvalue.test.ts
+++ b/generators/test/keyvalue.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { keyValue, keyValueList } from "..";
 
-function kvTest(
+function kvSuggestionsTest(
   generator: Fig.Generator
 ): (token: string, expected: Fig.Suggestion[]) => Promise<void> {
   return async (token, expected) => {
@@ -50,7 +50,7 @@ describe("Test keyValue suggestions", () => {
   });
 
   it("suggests keys and values correctly", async () => {
-    const test = kvTest(
+    const test = kvSuggestionsTest(
       keyValue({
         keys: ["a", "b", "c"],
         values: ["1", "2", "3"],
@@ -65,7 +65,7 @@ describe("Test keyValue suggestions", () => {
   });
 
   it("runs functions", async () => {
-    const test = kvTest(
+    const test = kvSuggestionsTest(
       keyValue({
         keys: () => Promise.resolve([{ name: "key" }]),
         values: () => Promise.resolve([{ name: "value" }]),
@@ -89,7 +89,7 @@ describe("Test keyValue suggestions", () => {
       getValuesCalled += 1;
       return [{ name: "value" }];
     };
-    const test = kvTest(
+    const test = kvSuggestionsTest(
       keyValue({
         keys: getKeys,
         values: getValues,
@@ -148,7 +148,7 @@ describe("Test keyValueList suggestions", () => {
   });
 
   it("suggests keys and values correctly", async () => {
-    const test = kvTest(
+    const test = kvSuggestionsTest(
       keyValueList({
         keys: ["a", "b", "c"],
         values: ["1", "2", "3"],
@@ -172,7 +172,7 @@ describe("Test keyValueList suggestions", () => {
   });
 
   it("runs functions", async () => {
-    const test = kvTest(
+    const test = kvSuggestionsTest(
       keyValueList({
         keys: () => Promise.resolve([{ name: "key" }]),
         values: () => Promise.resolve([{ name: "value" }]),
@@ -196,7 +196,7 @@ describe("Test keyValueList suggestions", () => {
       getValuesCalled += 1;
       return [{ name: "value" }];
     };
-    const test = kvTest(
+    const test = kvSuggestionsTest(
       keyValueList({
         keys: getKeys,
         values: getValues,

--- a/generators/test/keyvalue.test.ts
+++ b/generators/test/keyvalue.test.ts
@@ -119,6 +119,90 @@ describe("Test keyValue suggestions", () => {
     expect(getKeysCalled).to.be.equal(1);
     expect(getValuesCalled).to.be.equal(1);
   });
+
+  it("can cache keys independently", async () => {
+    let getKeysCalled = 0;
+    const getKeys = async () => {
+      getKeysCalled += 1;
+      return [{ name: "key" }];
+    };
+    let getValuesCalled = 0;
+    const getValues = async () => {
+      getValuesCalled += 1;
+      return [{ name: "value" }];
+    };
+    const test = kvSuggestionsTest(
+      keyValue({
+        keys: getKeys,
+        values: getValues,
+        cache: "keys",
+      })
+    );
+    expect(getKeysCalled).to.be.equal(0);
+    expect(getValuesCalled).to.be.equal(0);
+
+    await test("", [{ name: "key" }]);
+    expect(getKeysCalled).to.be.equal(1);
+    expect(getValuesCalled).to.be.equal(0);
+
+    await test("key", [{ name: "key" }]);
+    expect(getKeysCalled).to.be.equal(1);
+    expect(getValuesCalled).to.be.equal(0);
+
+    await test("key=", [{ name: "value" }]);
+    expect(getKeysCalled).to.be.equal(1);
+    expect(getValuesCalled).to.be.equal(1);
+
+    await test("key=val", [{ name: "value" }]);
+    expect(getKeysCalled).to.be.equal(1);
+    expect(getValuesCalled).to.be.equal(2);
+
+    await test("key=val=", [{ name: "value" }]);
+    expect(getKeysCalled).to.be.equal(1);
+    expect(getValuesCalled).to.be.equal(3);
+  });
+
+  it("can cache values independently", async () => {
+    let getKeysCalled = 0;
+    const getKeys = async () => {
+      getKeysCalled += 1;
+      return [{ name: "key" }];
+    };
+    let getValuesCalled = 0;
+    const getValues = async () => {
+      getValuesCalled += 1;
+      return [{ name: "value" }];
+    };
+    const test = kvSuggestionsTest(
+      keyValue({
+        keys: getKeys,
+        values: getValues,
+        cache: "values",
+      })
+    );
+    expect(getKeysCalled).to.be.equal(0);
+    expect(getValuesCalled).to.be.equal(0);
+
+    await test("", [{ name: "key" }]);
+    expect(getKeysCalled).to.be.equal(1);
+    expect(getValuesCalled).to.be.equal(0);
+
+    await test("key", [{ name: "key" }]);
+    expect(getKeysCalled).to.be.equal(2);
+    expect(getValuesCalled).to.be.equal(0);
+
+    await test("key=", [{ name: "value" }]);
+    expect(getKeysCalled).to.be.equal(2);
+    expect(getValuesCalled).to.be.equal(1);
+
+    await test("key=val", [{ name: "value" }]);
+    expect(getKeysCalled).to.be.equal(2);
+    expect(getValuesCalled).to.be.equal(1);
+
+    await test("key=val=", [{ name: "value" }]);
+    expect(getKeysCalled).to.be.equal(2);
+    expect(getValuesCalled).to.be.equal(1);
+  });
 });
 
 describe("Test keyValueList suggestions", () => {
@@ -236,6 +320,120 @@ describe("Test keyValueList suggestions", () => {
 
     await test("key=val,key=val", [{ name: "value" }]);
     expect(getKeysCalled).to.be.equal(1);
+    expect(getValuesCalled).to.be.equal(1);
+  });
+
+  it("can cache keys independently", async () => {
+    let getKeysCalled = 0;
+    const getKeys = async () => {
+      getKeysCalled += 1;
+      return [{ name: "key" }];
+    };
+
+    let getValuesCalled = 0;
+    const getValues = async () => {
+      getValuesCalled += 1;
+      return [{ name: "value" }];
+    };
+
+    const test = kvSuggestionsTest(
+      keyValueList({
+        keys: getKeys,
+        values: getValues,
+        cache: "keys",
+      })
+    );
+
+    expect(getKeysCalled).to.be.equal(0);
+    expect(getValuesCalled).to.be.equal(0);
+
+    await test("", [{ name: "key" }]);
+    expect(getKeysCalled).to.be.equal(1);
+    expect(getValuesCalled).to.be.equal(0);
+
+    await test("key", [{ name: "key" }]);
+    expect(getKeysCalled).to.be.equal(1);
+    expect(getValuesCalled).to.be.equal(0);
+
+    await test("key=", [{ name: "value" }]);
+    expect(getKeysCalled).to.be.equal(1);
+    expect(getValuesCalled).to.be.equal(1);
+
+    await test("key=val", [{ name: "value" }]);
+    expect(getKeysCalled).to.be.equal(1);
+    expect(getValuesCalled).to.be.equal(2);
+
+    await test("key=val,", [{ name: "key" }]);
+    expect(getKeysCalled).to.be.equal(1);
+    expect(getValuesCalled).to.be.equal(2);
+
+    await test("key=val,key", [{ name: "key" }]);
+    expect(getKeysCalled).to.be.equal(1);
+    expect(getValuesCalled).to.be.equal(2);
+
+    await test("key=val,key=", [{ name: "value" }]);
+    expect(getKeysCalled).to.be.equal(1);
+    expect(getValuesCalled).to.be.equal(3);
+
+    await test("key=val,key=val", [{ name: "value" }]);
+    expect(getKeysCalled).to.be.equal(1);
+    expect(getValuesCalled).to.be.equal(4);
+  });
+
+  it("can cache values independently", async () => {
+    let getKeysCalled = 0;
+    const getKeys = async () => {
+      getKeysCalled += 1;
+      return [{ name: "key" }];
+    };
+
+    let getValuesCalled = 0;
+    const getValues = async () => {
+      getValuesCalled += 1;
+      return [{ name: "value" }];
+    };
+
+    const test = kvSuggestionsTest(
+      keyValueList({
+        keys: getKeys,
+        values: getValues,
+        cache: "values",
+      })
+    );
+
+    expect(getKeysCalled).to.be.equal(0);
+    expect(getValuesCalled).to.be.equal(0);
+
+    await test("", [{ name: "key" }]);
+    expect(getKeysCalled).to.be.equal(1);
+    expect(getValuesCalled).to.be.equal(0);
+
+    await test("key", [{ name: "key" }]);
+    expect(getKeysCalled).to.be.equal(2);
+    expect(getValuesCalled).to.be.equal(0);
+
+    await test("key=", [{ name: "value" }]);
+    expect(getKeysCalled).to.be.equal(2);
+    expect(getValuesCalled).to.be.equal(1);
+
+    await test("key=val", [{ name: "value" }]);
+    expect(getKeysCalled).to.be.equal(2);
+    expect(getValuesCalled).to.be.equal(1);
+
+    await test("key=val,", [{ name: "key" }]);
+    expect(getKeysCalled).to.be.equal(3);
+    expect(getValuesCalled).to.be.equal(1);
+
+    await test("key=val,key", [{ name: "key" }]);
+    expect(getKeysCalled).to.be.equal(4);
+    expect(getValuesCalled).to.be.equal(1);
+
+    await test("key=val,key=", [{ name: "value" }]);
+    expect(getKeysCalled).to.be.equal(4);
+    expect(getValuesCalled).to.be.equal(1);
+
+    await test("key=val,key=val", [{ name: "value" }]);
+    expect(getKeysCalled).to.be.equal(4);
     expect(getValuesCalled).to.be.equal(1);
   });
 });


### PR DESCRIPTION
Keys and values can be cached independently, so you can use the cache for static values but ignore it for dynamic suggestions
```ts
keyValue({
  keys: async () => [ /* ... */ ],
  values: async (tokens) => ({ name: tokens[tokens.length - 1] }),
  cache: "keys",
});
```

There's a new function called `valueList` which uses the same cache.
```ts
valueList({
  values: [ /* ... */ ],
  cache: true,
});
```

And you can now enable/disable inserting the separator and delimiter. By default, the separator will be inserted (like how `requiresSeparator` works), but the delimiter won't be inserted unless manually enabled.