### PR TITLE
feat(types): add `Subcommand.requiresSubcommand`

### DIFF
--- a/types/docs.json
+++ b/types/docs.json
@@ -293,6 +293,16 @@
           "hasDocComment": true
         },
         {
+          "name": "requiresSubcommand",
+          "excluded": false,
+          "summary": "Specifies whether the command requires a subcommand. This is false by default.\n\nA space will always be inserted after this command if `requiresSubcommand` is true.\nIf the property is omitted, a space will be inserted if there is at least one required argument.",
+          "parameters": [],
+          "optional": true,
+          "declaration": "requiresSubcommand?: boolean",
+          "examples": [],
+          "hasDocComment": true
+        },
+        {
           "name": "options",
           "excluded": false,
           "summary": "An array of `Option` objects representing the options that are available on this subcommand.",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -439,6 +439,14 @@ declare namespace Fig {
     subcommands?: Subcommand[];
 
     /**
+     * Specifies whether the command requires a subcommand. This is false by default.
+     *
+     * A space will always be inserted after this command if `requiresSubcommand` is true.
+     * If the property is omitted, a space will be inserted if there is at least one required argument.
+     */
+    requiresSubcommand?: boolean;
+
+    /**
      * An array of `Option` objects representing the options that are available on this subcommand.
      *
      * @example


### PR DESCRIPTION
Optional property that, when true (unless configured otherwise) will maintain the *current* behavior of inserting a space after the subcommand name. If it's false or omitted, and there are no required arguments, no space will be inserted.

The behavior in AE isn't implemented yet, but I want to handle that myself