### PR TITLE
fix(cobra): `[]flag` should be repeatable

### DIFF
--- a/integrations/cobra/main.go
+++ b/integrations/cobra/main.go
@@ -110,6 +110,10 @@ func subcommands(cmd *cobra.Command, overrideOptions bool, overrides Options) Su
 	return subs
 }
 
+func isFlagRepeatable(flag *pflag.Flag) bool {
+	return strings.Contains(flag.Value.Type(), "Slice") || strings.Contains(flag.Value.Type(), "Array")
+}
+
 func options(flagSet *pflag.FlagSet, persistent bool) []Option {
 	var opts []Option
 	attachFlags := func(flag *pflag.Flag) {
@@ -120,7 +124,7 @@ func options(flagSet *pflag.FlagSet, persistent bool) []Option {
 				hidden: flag.Hidden,
 			},
 			name:         []string{fmt.Sprintf("--%v", flag.Name)},
-			isRepeatable: strings.Contains(strings.ToLower(flag.Value.Type()), "array"),
+			isRepeatable: isFlagRepeatable(flag),
 		}
 		if flag.Shorthand != "" {
 			option.name = append(option.name, fmt.Sprintf("-%v", flag.Shorthand))


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix for https://github.com/withfig/autocomplete/pull/1419#discussion_r947771946.

**What is the current behavior? (You can also link to an open issue here)**

Cobra flags in the format of `[]string` are currently being generated as `isRepeatable: false`.

**What is the new behavior (if this is a feature change)?**

Cobra flags in the format of `[]string` will start being generated as `isRepeatable: true`.

**Additional info:**

This was tested in this other PR I've got in the works adding automatic support to Fig in Meroxa's CLI: https://github.com/meroxa/cli/pull/403/commits/41ac593d7df6e316c492c1d95fd28ab537f034c3.

To reproduce, you could run `make fig` to generate a spec using this version of Cobra's generator.